### PR TITLE
Optional piped input to Stdin - Issue 4

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,17 +23,25 @@ func main() {
 	var columnNum int
 	var columnCounts = make(map[int]int)
 	var lines []string
-	f, err := os.Open(fn)
-	if err != nil {
-		log.Fatalln(err)
+	var scanner *bufio.Scanner
+
+	fi, _ := os.Stdin.Stat()
+	if (fi.Mode() & os.ModeCharDevice) == 0 {
+		scanner = bufio.NewScanner(os.Stdin)
+	} else {
+		f, err := os.Open(fn)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer f.Close()
+		scanner = bufio.NewScanner(f)
 	}
-	defer f.Close()
+
 	out, err := os.Create("out" + fn)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	defer out.Close()
-	scanner := bufio.NewScanner(f)
 
 	for scanner.Scan() {
 		temp := 0

--- a/main.go
+++ b/main.go
@@ -13,6 +13,12 @@ const (
 	fn        = "things.csv"
 )
 
+// ScanWriter scans input and writes output
+type ScanWriter struct {
+	s *bufio.Scanner
+	w *bufio.Writer
+}
+
 func main() {
 	var columnNum int
 	var columnCounts = make(map[int]int)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -19,34 +20,62 @@ type ScanWriter struct {
 	w *bufio.Writer
 }
 
+func newScanWriter(in io.Reader, out io.Writer) *ScanWriter {
+	return &ScanWriter{
+		s: bufio.NewScanner(in),
+		w: bufio.NewWriter(out),
+	}
+}
+
 func main() {
 	var columnNum int
 	var columnCounts = make(map[int]int)
 	var lines []string
-	var scanner *bufio.Scanner
+	var sw *ScanWriter
 
 	fi, _ := os.Stdin.Stat()
 	if (fi.Mode() & os.ModeCharDevice) == 0 {
-		scanner = bufio.NewScanner(os.Stdin)
-	} else {
-		f, err := os.Open(fn)
-		if err != nil {
-			log.Fatalln(err)
+		switch len(os.Args) {
+		case 2:
+			f, err := os.Create(os.Args[1])
+			if err != nil {
+				log.Fatalln(err)
+			}
+			defer f.Close()
+			sw = newScanWriter(os.Stdin, f)
+		default:
+			sw = newScanWriter(os.Stdin, os.Stdout)
 		}
-		defer f.Close()
-		scanner = bufio.NewScanner(f)
+	} else {
+		switch len(os.Args) {
+		case 2:
+			f, err := os.Open(os.Args[1])
+			if err != nil {
+				log.Fatalln(err)
+			}
+			defer f.Close()
+			sw = newScanWriter(f, os.Stdout)
+		case 3:
+			f, err := os.Open(os.Args[1])
+			if err != nil {
+				log.Fatalln(err)
+			}
+			defer f.Close()
+			out, err := os.Create(os.Args[2])
+			if err != nil {
+				log.Fatalln(err)
+			}
+			defer out.Close()
+			sw = newScanWriter(f, out)
+		default:
+			sw = newScanWriter(os.Stdin, os.Stdout)
+		}
 	}
 
-	out, err := os.Create("out" + fn)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	defer out.Close()
-
-	for scanner.Scan() {
+	for sw.s.Scan() {
 		temp := 0
 		columnNum = 0
-		line := scanner.Text()
+		line := sw.s.Text()
 		for i, v := range line {
 			temp += utf8.RuneLen(v)
 			if v != delimiter && i < len(line)-1 {
@@ -61,8 +90,6 @@ func main() {
 		lines = append(lines, line)
 	}
 
-	w := bufio.NewWriter(out)
-	// w := bufio.NewWriter(os.Stdout)
 	for _, line := range lines {
 		words := strings.Split(line, string(delimiter))
 		columnNum = 0
@@ -79,12 +106,12 @@ func main() {
 			columnNum++
 			// since columnNum was just incremented, do not add a comma to the last field
 			if _, ok := columnCounts[columnNum]; ok {
-				w.WriteString(word + string(delimiter))
+				sw.w.WriteString(word + string(delimiter))
 				continue
 			}
-			w.WriteString(word)
+			sw.w.WriteString(word)
 		}
-		w.WriteByte('\n')
+		sw.w.WriteByte('\n')
 	}
-	w.Flush()
+	sw.w.Flush()
 }


### PR DESCRIPTION
Fixes #4 
* Implement a ScanWriter type
* If input is piped to Stdin, then that will be used to initialize the ScanWriter
* Provide command line args as input/output file names